### PR TITLE
Refactor array reading operations with intuitive JavaScript-inspired API

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ const results = await db
     pg.array("tags").length().as("tag_count"),
     pg.json("metadata").path("author").asText().as("author"),
   ])
-  .where(pg.array("tags").includes("typescript")) // tags @> ARRAY['typescript']
+  .where(pg.array("tags").hasAllOf(["typescript"])) // tags @> ARRAY['typescript']
   .where(pg.json("metadata").path("published").equals(true)) // metadata#>'{"published"}' = true
   .where(pg.vector("embedding").similarTo(searchVector)) // embedding <-> $1 < 0.5
   .orderBy("tag_count", "desc")
@@ -53,23 +53,17 @@ Work with PostgreSQL arrays like you would with JavaScript arrays, but with data
 ```typescript
 import { pg } from 'kysely-helpers'
 
-// Does tags array contain 'featured'? → tags @> ARRAY['featured']
-.where(pg.array('tags').includes('featured'))
+// Does tags array contain all of ['featured']? → tags @> ARRAY['featured']
+.where(pg.array('tags').hasAllOf(['featured']))
 
 // Does tags array contain both 'ai' AND 'ml'? → tags @> ARRAY['ai', 'ml']
-.where(pg.array('tags').contains(['ai', 'ml']))
+.where(pg.array('tags').hasAllOf(['ai', 'ml']))
 
 // Do categories share ANY values with ['tech', 'ai']? → categories && ARRAY['tech', 'ai']
-.where(pg.array('categories').overlaps(['tech', 'ai']))
-
-// Are all sizes within the allowed list? → sizes <@ ARRAY['S', 'M', 'L']
-.where(pg.array('sizes').containedBy(['S', 'M', 'L']))
+.where(pg.array('categories').hasAnyOf(['tech', 'ai']))
 
 // Does array have more than 5 items? → array_length(items, 1) > 5
 .where(pg.array('items').length(), '>', 5)
-
-// Is status one of the valid options? → status = ANY(valid_statuses)
-.where('status', '=', pg.array('valid_statuses').any())
 
 // Get first element → tags[1]
 .select(pg.array('tags').first().as('first_tag'))
@@ -299,10 +293,10 @@ const products = await db
     pg.array("tags").length().as("tag_count"),
     pg.json("metadata").path("difficulty").asText().as("difficulty"),
   ])
-  .where(pg.array("categories").includes("electronics"))
+  .where(pg.array("categories").hasAllOf(["electronics"]))
   .where(pg.json("specs").path(["display", "size"]).equals(15))
   .where(pg.json("availability").hasKey("in_stock"))
-  .where(pg.array("tags").overlaps(["featured", "bestseller"]))
+  .where(pg.array("tags").hasAnyOf(["featured", "bestseller"]))
   .orderBy("tag_count", "desc")
   .execute();
 ```
@@ -328,7 +322,7 @@ const results = await db
       .as("similarity"),
     pg.array("tags").length().as("tag_count"),
   ])
-  .where(pg.array("tags").overlaps(["ai", "machine-learning"]))
+  .where(pg.array("tags").hasAnyOf(["ai", "machine-learning"]))
   .where(pg.json("metadata").path("published").equals(true))
   .where(
     pg.vector("embedding").similarTo(searchEmbedding.data[0].embedding, 0.8)
@@ -352,7 +346,7 @@ const userData = await db
       .path(["notifications", "email"])
       .as("email_notifications"),
   ])
-  .where(pg.array("roles").includes("admin"))
+  .where(pg.array("roles").hasAllOf(["admin"]))
   .where(pg.json("preferences").hasKey("theme"))
   .where(pg.json("profile").contains({ verified: true, active: true }))
   .execute();

--- a/tests/integration/database.test.ts
+++ b/tests/integration/database.test.ts
@@ -111,7 +111,7 @@ describe('Integration Tests - Real PostgreSQL Database', () => {
       const results = await db
         .selectFrom('products')
         .select(['id', 'name', 'tags'])
-        .where(pg.array('tags').includes('typescript'))
+        .where(pg.array('tags').hasAllOf(['typescript']))
         .execute()
 
       expect(results).toBeDefined()
@@ -128,7 +128,7 @@ describe('Integration Tests - Real PostgreSQL Database', () => {
       const results = await db
         .selectFrom('products')
         .select(['id', 'name', 'tags'])
-        .where(pg.array('tags').contains(['tutorial', 'programming']))
+        .where(pg.array('tags').hasAllOf(['tutorial', 'programming']))
         .execute()
 
       expect(results).toBeDefined()
@@ -145,7 +145,7 @@ describe('Integration Tests - Real PostgreSQL Database', () => {
       const results = await db
         .selectFrom('products')
         .select(['id', 'name', 'categories'])
-        .where(pg.array('categories').overlaps(['education', 'electronics']))
+        .where(pg.array('categories').hasAnyOf(['education', 'electronics']))
         .execute()
 
       expect(results).toBeDefined()
@@ -189,8 +189,8 @@ describe('Integration Tests - Real PostgreSQL Database', () => {
           'categories',
           pg.array('tags').length().as('tag_count')
         ])
-        .where(pg.array('tags').includes('tutorial'))
-        .where(pg.array('categories').overlaps(['education']))
+        .where(pg.array('tags').hasAllOf(['tutorial']))
+        .where(pg.array('categories').hasAnyOf(['education']))
         .where(pg.array('tags').length(), '>=', 3)
         .orderBy('name')
         .execute()
@@ -389,9 +389,9 @@ describe('Integration Tests - Real PostgreSQL Database', () => {
           pg.array('tags').length().as('tag_count'),
           pg.json('metadata').path('difficulty').asText().as('difficulty')
         ])
-        .where(pg.array('tags').includes('tutorial'))
+        .where(pg.array('tags').hasAllOf(['tutorial']))
         .where(pg.json('metadata').path('difficulty').equals('beginner'))
-        .where(pg.array('categories').overlaps(['education']))
+        .where(pg.array('categories').hasAnyOf(['education']))
         .execute()
 
       expect(results).toBeDefined()
@@ -420,7 +420,7 @@ describe('Integration Tests - Real PostgreSQL Database', () => {
           pg.json('metadata').path('difficulty').asText().as('difficulty'),
           pg.json('metadata').path('rating').asText().as('rating')
         ])
-        .where(pg.array('tags').overlaps(userInterests))
+        .where(pg.array('tags').hasAnyOf(userInterests))
         .where(pg.json('metadata').hasKey('difficulty'))
         .where(pg.array('tags').length(), '>=', 3)
         .orderBy('rating', 'desc')
@@ -453,7 +453,7 @@ describe('Integration Tests - Real PostgreSQL Database', () => {
           pg.json('preferences').path(['notifications', 'email']).asText().as('email_notifications'),
           pg.array('roles').length().as('role_count')
         ])
-        .where(pg.array('roles').includes('user'))
+        .where(pg.array('roles').hasAllOf(['user']))
         .where(pg.json('permissions').path('read').equals(true))
         .where(pg.json('preferences').hasKey('theme'))
         .orderBy('name')
@@ -478,7 +478,7 @@ describe('Integration Tests - Real PostgreSQL Database', () => {
       const results = await db
         .selectFrom('products')
         .select(['id', 'name'])
-        .where(pg.array('tags').overlaps(largeTagArray))
+        .where(pg.array('tags').hasAnyOf(largeTagArray))
         .execute()
 
       expect(results).toBeDefined()
@@ -489,7 +489,7 @@ describe('Integration Tests - Real PostgreSQL Database', () => {
       const results = await db
         .selectFrom('products')
         .select(['id', 'name', 'tags'])
-        .where(pg.array('tags').contains([]))
+        .where(pg.array('tags').hasAllOf([]))
         .execute()
 
       expect(results).toBeDefined()
@@ -523,7 +523,7 @@ describe('Integration Tests - Real PostgreSQL Database', () => {
       const results = await db
         .selectFrom('products')
         .select(['id', 'name'])
-        .where(pg.array('tags').includes(maliciousInput))
+        .where(pg.array('tags').hasAllOf([maliciousInput]))
         .execute()
 
       expect(results).toBeDefined()

--- a/tests/pg/array/api.test.ts
+++ b/tests/pg/array/api.test.ts
@@ -6,12 +6,11 @@ describe('Array API', () => {
     test('pg.array() creates function with expected methods', () => {
       const arrayOps = pg.array('tags')
       
-      expect(typeof arrayOps.contains).toBe('function')
-      expect(typeof arrayOps.includes).toBe('function')
-      expect(typeof arrayOps.overlaps).toBe('function')
-      expect(typeof arrayOps.containedBy).toBe('function')
+      expect(typeof arrayOps.hasAllOf).toBe('function')
+      expect(typeof arrayOps.hasAnyOf).toBe('function')
       expect(typeof arrayOps.length).toBe('function')
-      expect(typeof arrayOps.any).toBe('function')
+      expect(typeof arrayOps.first).toBe('function')
+      expect(typeof arrayOps.last).toBe('function')
     })
 
     test('typed arrays maintain type information', () => {
@@ -20,13 +19,13 @@ describe('Array API', () => {
       const booleanArray = pg.array<boolean>('flags')
       
       // All should have the same interface
-      expect(typeof stringArray.includes).toBe('function')
-      expect(typeof numberArray.includes).toBe('function')
-      expect(typeof booleanArray.includes).toBe('function')
+      expect(typeof stringArray.hasAllOf).toBe('function')
+      expect(typeof numberArray.hasAllOf).toBe('function')
+      expect(typeof booleanArray.hasAllOf).toBe('function')
       
-      expect(typeof stringArray.contains).toBe('function')
-      expect(typeof numberArray.contains).toBe('function')
-      expect(typeof booleanArray.contains).toBe('function')
+      expect(typeof stringArray.hasAnyOf).toBe('function')
+      expect(typeof numberArray.hasAnyOf).toBe('function')
+      expect(typeof booleanArray.hasAnyOf).toBe('function')
     })
 
     test('works with different column name formats', () => {
@@ -39,43 +38,20 @@ describe('Array API', () => {
   })
 
   describe('Method calls and parameters', () => {
-    test('includes() accepts single values', () => {
+    test('hasAllOf() accepts arrays', () => {
       const arrayOps = pg.array('tags')
       
-      expect(() => arrayOps.includes('typescript')).not.toThrow()
-      expect(() => arrayOps.includes('')).not.toThrow()
-      expect(() => arrayOps.includes('tag with spaces')).not.toThrow()
+      expect(() => arrayOps.hasAllOf(['typescript', 'javascript'])).not.toThrow()
+      expect(() => arrayOps.hasAllOf([])).not.toThrow()
+      expect(() => arrayOps.hasAllOf(['single'])).not.toThrow()
     })
 
-    test('contains() accepts single values', () => {
-      const arrayOps = pg.array('tags')
-      
-      expect(() => arrayOps.contains('typescript')).not.toThrow()
-      expect(() => arrayOps.contains('')).not.toThrow()
-    })
-
-    test('contains() accepts arrays', () => {
-      const arrayOps = pg.array('tags')
-      
-      expect(() => arrayOps.contains(['typescript', 'javascript'])).not.toThrow()
-      expect(() => arrayOps.contains([])).not.toThrow()
-      expect(() => arrayOps.contains(['single'])).not.toThrow()
-    })
-
-    test('overlaps() accepts arrays', () => {
+    test('hasAnyOf() accepts arrays', () => {
       const arrayOps = pg.array('categories')
       
-      expect(() => arrayOps.overlaps(['tech', 'ai'])).not.toThrow()
-      expect(() => arrayOps.overlaps([])).not.toThrow()
-      expect(() => arrayOps.overlaps(['single'])).not.toThrow()
-    })
-
-    test('containedBy() accepts arrays', () => {
-      const arrayOps = pg.array('tags')
-      
-      expect(() => arrayOps.containedBy(['allowed', 'valid'])).not.toThrow()
-      expect(() => arrayOps.containedBy([])).not.toThrow()
-      expect(() => arrayOps.containedBy(['single'])).not.toThrow()
+      expect(() => arrayOps.hasAnyOf(['tech', 'ai'])).not.toThrow()
+      expect(() => arrayOps.hasAnyOf([])).not.toThrow()
+      expect(() => arrayOps.hasAnyOf(['single'])).not.toThrow()
     })
 
     test('length() requires no parameters', () => {
@@ -84,10 +60,16 @@ describe('Array API', () => {
       expect(() => arrayOps.length()).not.toThrow()
     })
 
-    test('any() requires no parameters', () => {
-      const arrayOps = pg.array('statuses')
+    test('first() requires no parameters', () => {
+      const arrayOps = pg.array('queue')
       
-      expect(() => arrayOps.any()).not.toThrow()
+      expect(() => arrayOps.first()).not.toThrow()
+    })
+
+    test('last() requires no parameters', () => {
+      const arrayOps = pg.array('stack')
+      
+      expect(() => arrayOps.last()).not.toThrow()
     })
   })
 
@@ -96,10 +78,8 @@ describe('Array API', () => {
       const stringOps = pg.array<string>('string_tags')
       
       expect(() => {
-        stringOps.includes('test')
-        stringOps.contains(['a', 'b', 'c'])
-        stringOps.overlaps(['x', 'y'])
-        stringOps.containedBy(['allowed'])
+        stringOps.hasAllOf(['a', 'b', 'c'])
+        stringOps.hasAnyOf(['x', 'y'])
       }).not.toThrow()
     })
 
@@ -107,10 +87,8 @@ describe('Array API', () => {
       const numberOps = pg.array<number>('scores')
       
       expect(() => {
-        numberOps.includes(42)
-        numberOps.contains([1, 2, 3])
-        numberOps.overlaps([10, 20])
-        numberOps.containedBy([1, 2, 3, 4, 5])
+        numberOps.hasAllOf([1, 2, 3])
+        numberOps.hasAnyOf([10, 20])
       }).not.toThrow()
     })
 
@@ -118,10 +96,8 @@ describe('Array API', () => {
       const booleanOps = pg.array<boolean>('flags')
       
       expect(() => {
-        booleanOps.includes(true)
-        booleanOps.contains([true, false])
-        booleanOps.overlaps([false])
-        booleanOps.containedBy([true, false])
+        booleanOps.hasAllOf([true, false])
+        booleanOps.hasAnyOf([false])
       }).not.toThrow()
     })
   })
@@ -131,9 +107,8 @@ describe('Array API', () => {
       const arrayOps = pg.array('tags')
       
       expect(() => {
-        arrayOps.contains([])
-        arrayOps.overlaps([])
-        arrayOps.containedBy([])
+        arrayOps.hasAllOf([])
+        arrayOps.hasAnyOf([])
       }).not.toThrow()
     })
 
@@ -141,9 +116,8 @@ describe('Array API', () => {
       const arrayOps = pg.array('tags')
       
       expect(() => {
-        arrayOps.contains(['single'])
-        arrayOps.overlaps(['single'])
-        arrayOps.containedBy(['single'])
+        arrayOps.hasAllOf(['single'])
+        arrayOps.hasAnyOf(['single'])
       }).not.toThrow()
     })
 
@@ -152,9 +126,8 @@ describe('Array API', () => {
       const largeArray = Array.from({length: 100}, (_, i) => `item${i}`)
       
       expect(() => {
-        arrayOps.contains(largeArray)
-        arrayOps.overlaps(largeArray)
-        arrayOps.containedBy(largeArray)
+        arrayOps.hasAllOf(largeArray)
+        arrayOps.hasAnyOf(largeArray)
       }).not.toThrow()
     })
 
@@ -162,10 +135,8 @@ describe('Array API', () => {
       const arrayOps = pg.array('tags')
       
       expect(() => {
-        arrayOps.includes("tag's with 'quotes'")
-        arrayOps.contains(['tag"with"quotes', 'tag\\with\\backslashes'])
-        arrayOps.overlaps(['unicode: 🚀', 'newline:\nchar'])
-        arrayOps.containedBy(['tab:\tchar', 'null:\0char'])
+        arrayOps.hasAllOf(['tag"with"quotes', 'tag\\with\\backslashes'])
+        arrayOps.hasAnyOf(['unicode: 🚀', 'newline:\nchar'])
       }).not.toThrow()
     })
 
@@ -173,10 +144,8 @@ describe('Array API', () => {
       const arrayOps = pg.array('tags')
       
       expect(() => {
-        arrayOps.includes('')
-        arrayOps.contains(['', 'non-empty'])
-        arrayOps.overlaps([''])
-        arrayOps.containedBy(['', 'allowed'])
+        arrayOps.hasAllOf(['', 'non-empty'])
+        arrayOps.hasAnyOf([''])
       }).not.toThrow()
     })
   })
@@ -186,36 +155,33 @@ describe('Array API', () => {
       const arrayOps = pg.array('tags')
       
       // These should return objects that look like Kysely expressions
-      const includesExpr = arrayOps.includes('test')
-      const containsExpr = arrayOps.contains(['a', 'b'])
-      const overlapsExpr = arrayOps.overlaps(['x', 'y'])
-      const containedByExpr = arrayOps.containedBy(['allowed'])
+      const hasAllOfExpr = arrayOps.hasAllOf(['a', 'b'])
+      const hasAnyOfExpr = arrayOps.hasAnyOf(['x', 'y'])
       const lengthExpr = arrayOps.length()
-      const anyExpr = arrayOps.any()
+      const firstExpr = arrayOps.first()
+      const lastExpr = arrayOps.last()
       
       // All should be objects (Kysely expressions)
-      expect(typeof includesExpr).toBe('object')
-      expect(typeof containsExpr).toBe('object')
-      expect(typeof overlapsExpr).toBe('object')
-      expect(typeof containedByExpr).toBe('object')
+      expect(typeof hasAllOfExpr).toBe('object')
+      expect(typeof hasAnyOfExpr).toBe('object')
       expect(typeof lengthExpr).toBe('object')
-      expect(typeof anyExpr).toBe('object')
+      expect(typeof firstExpr).toBe('object')
+      expect(typeof lastExpr).toBe('object')
       
       // Should not be null
-      expect(includesExpr).not.toBeNull()
-      expect(containsExpr).not.toBeNull()
-      expect(overlapsExpr).not.toBeNull()
-      expect(containedByExpr).not.toBeNull()
+      expect(hasAllOfExpr).not.toBeNull()
+      expect(hasAnyOfExpr).not.toBeNull()
       expect(lengthExpr).not.toBeNull()
-      expect(anyExpr).not.toBeNull()
+      expect(firstExpr).not.toBeNull()
+      expect(lastExpr).not.toBeNull()
     })
 
     test('multiple operations can be created from same array instance', () => {
       const arrayOps = pg.array('tags')
       
       expect(() => {
-        const expr1 = arrayOps.includes('first')
-        const expr2 = arrayOps.contains(['second', 'third'])
+        const expr1 = arrayOps.hasAllOf(['first'])
+        const expr2 = arrayOps.hasAnyOf(['second', 'third'])
         const expr3 = arrayOps.length()
         
         // All should be independent expressions
@@ -229,32 +195,32 @@ describe('Array API', () => {
   describe('Column reference variations', () => {
     test('handles simple column names', () => {
       expect(() => {
-        pg.array('tags').includes('test')
+        pg.array('tags').hasAllOf(['test'])
         pg.array('categories').length()
-        pg.array('scores').any()
+        pg.array('scores').first()
       }).not.toThrow()
     })
 
     test('handles qualified column names', () => {
       expect(() => {
-        pg.array('products.tags').includes('featured')
-        pg.array('user.preferences').contains(['dark_mode'])
-        pg.array('order.items').overlaps(['item1', 'item2', 'item3'])
+        pg.array('products.tags').hasAllOf(['featured'])
+        pg.array('user.preferences').hasAnyOf(['dark_mode'])
+        pg.array('order.items').hasAnyOf(['item1', 'item2', 'item3'])
       }).not.toThrow()
     })
 
     test('handles aliased table columns', () => {
       expect(() => {
-        pg.array('p.categories').overlaps(['electronics'])
-        pg.array('u.roles').containedBy(['admin', 'user'])
+        pg.array('p.categories').hasAnyOf(['electronics'])
+        pg.array('u.roles').hasAllOf(['admin', 'user'])
         pg.array('o.statuses').length()
       }).not.toThrow()
     })
 
     test('handles quoted identifiers', () => {
       expect(() => {
-        pg.array('"quoted_column"').includes('value')
-        pg.array('"table"."column"').contains(['items'])
+        pg.array('"quoted_column"').hasAllOf(['value'])
+        pg.array('"table"."column"').hasAnyOf(['items'])
         pg.array('"schema"."table"."column"').length()
       }).not.toThrow()
     })

--- a/tests/pg/array/security.test.ts
+++ b/tests/pg/array/security.test.ts
@@ -77,13 +77,13 @@ afterAll(async () => {
 
 describe('Array Security Tests', () => {
   describe('SQL Injection Prevention - Compilation Tests', () => {
-    test('malicious SQL in includes() is parameterized', () => {
+    test('malicious SQL in hasAllOf() is parameterized', () => {
       const maliciousInput = "'; DROP TABLE products; --"
       
       const query = compileDb
         .selectFrom('products')
         .selectAll()
-        .where(pg.array('tags').includes(maliciousInput))
+        .where(pg.array('tags').hasAllOf([maliciousInput]))
       
       const compiled = query.compile()
       
@@ -94,7 +94,7 @@ describe('Array Security Tests', () => {
       expect(compiled.parameters).toEqual([maliciousInput])
     })
 
-    test('malicious SQL in contains() array is parameterized', () => {
+    test('malicious SQL in hasAllOf() array is parameterized', () => {
       const maliciousArray = [
         "'; DELETE FROM products; --",
         "' OR 1=1; --",
@@ -104,7 +104,7 @@ describe('Array Security Tests', () => {
       const query = compileDb
         .selectFrom('products')
         .selectAll()
-        .where(pg.array('tags').contains(maliciousArray))
+        .where(pg.array('tags').hasAllOf(maliciousArray))
       
       const compiled = query.compile()
       
@@ -121,7 +121,7 @@ describe('Array Security Tests', () => {
       })
     })
 
-    test('SQL injection in overlaps() is prevented', () => {
+    test('SQL injection in hasAnyOf() is prevented', () => {
       const maliciousValues = [
         "admin'; DROP DATABASE test; --",
         "'; GRANT ALL ON *.* TO 'hacker'@'%'; --"
@@ -130,7 +130,7 @@ describe('Array Security Tests', () => {
       const query = compileDb
         .selectFrom('products')
         .selectAll()
-        .where(pg.array('categories').overlaps(maliciousValues))
+        .where(pg.array('categories').hasAnyOf(maliciousValues))
       
       const compiled = query.compile()
       
@@ -139,7 +139,7 @@ describe('Array Security Tests', () => {
       expect(compiled.parameters).toEqual(maliciousValues)
     })
 
-    test('SQL injection in containedBy() is prevented', () => {
+    test('SQL injection in hasAnyOf() is prevented', () => {
       const maliciousConstraints = [
         "allowed'; UPDATE products SET price = 0; --",
         "valid'; INSERT INTO admin_users VALUES ('hacker'); --"
@@ -148,7 +148,7 @@ describe('Array Security Tests', () => {
       const query = compileDb
         .selectFrom('products')
         .selectAll()
-        .where(pg.array('tags').containedBy(maliciousConstraints))
+        .where(pg.array('tags').hasAnyOf(maliciousConstraints))
       
       const compiled = query.compile()
       
@@ -163,7 +163,7 @@ describe('Array Security Tests', () => {
       const query = compileDb
         .selectFrom('products')
         .selectAll()
-        .where(pg.array('tags').includes(unionAttack))
+        .where(pg.array('tags').hasAllOf([unionAttack]))
       
       const compiled = query.compile()
       
@@ -178,7 +178,7 @@ describe('Array Security Tests', () => {
       const query = compileDb
         .selectFrom('products')
         .selectAll()
-        .where(pg.array('tags').contains([nestedAttack]))
+        .where(pg.array('tags').hasAllOf([nestedAttack]))
       
       const compiled = query.compile()
       
@@ -193,7 +193,7 @@ describe('Array Security Tests', () => {
       const query = compileDb
         .selectFrom('products')
         .selectAll()
-        .where(pg.array('tags').includes(timeAttack))
+        .where(pg.array('tags').hasAllOf([timeAttack]))
       
       const compiled = query.compile()
       
@@ -210,7 +210,7 @@ describe('Array Security Tests', () => {
       const query = compileDb
         .selectFrom('products')
         .selectAll()
-        .where(pg.array('tags').includes(valueWithQuotes))
+        .where(pg.array('tags').hasAllOf([valueWithQuotes]))
       
       const compiled = query.compile()
       
@@ -224,7 +224,7 @@ describe('Array Security Tests', () => {
       const query = compileDb
         .selectFrom('products')
         .selectAll()
-        .where(pg.array('tags').includes(valueWithDoubleQuotes))
+        .where(pg.array('tags').hasAllOf([valueWithDoubleQuotes]))
       
       const compiled = query.compile()
       
@@ -237,7 +237,7 @@ describe('Array Security Tests', () => {
       const query = compileDb
         .selectFrom('products')
         .selectAll()
-        .where(pg.array('tags').includes(valueWithBackslashes))
+        .where(pg.array('tags').hasAllOf([valueWithBackslashes]))
       
       const compiled = query.compile()
       
@@ -250,7 +250,7 @@ describe('Array Security Tests', () => {
       const query = compileDb
         .selectFrom('products')
         .selectAll()
-        .where(pg.array('tags').includes(valueWithNullByte))
+        .where(pg.array('tags').hasAllOf([valueWithNullByte]))
       
       const compiled = query.compile()
       
@@ -263,7 +263,7 @@ describe('Array Security Tests', () => {
       const query = compileDb
         .selectFrom('products')
         .selectAll()
-        .where(pg.array('tags').overlaps(unicodeValues))
+        .where(pg.array('tags').hasAnyOf(unicodeValues))
       
       const compiled = query.compile()
       
@@ -276,7 +276,7 @@ describe('Array Security Tests', () => {
       const query = compileDb
         .selectFrom('products')
         .selectAll()
-        .where(pg.array('tags').includes(controlChars))
+        .where(pg.array('tags').hasAllOf([controlChars]))
       
       const compiled = query.compile()
       
@@ -291,7 +291,7 @@ describe('Array Security Tests', () => {
       const query = compileDb
         .selectFrom('products')
         .selectAll()
-        .where(pg.array('tags').includes(longString))
+        .where(pg.array('tags').hasAllOf([longString]))
       
       const compiled = query.compile()
       
@@ -305,7 +305,7 @@ describe('Array Security Tests', () => {
       const query = compileDb
         .selectFrom('products')
         .selectAll()
-        .where(pg.array('tags').includes(emptyString))
+        .where(pg.array('tags').hasAllOf([emptyString]))
       
       const compiled = query.compile()
       
@@ -325,7 +325,7 @@ describe('Array Security Tests', () => {
       const query = compileDb
         .selectFrom('products')
         .selectAll()
-        .where(pg.array('tags').contains(dangerousArray))
+        .where(pg.array('tags').hasAllOf(dangerousArray))
       
       const compiled = query.compile()
       
@@ -347,7 +347,7 @@ describe('Array Security Tests', () => {
       const query = compileDb
         .selectFrom('products')
         .selectAll()
-        .where(pg.array('tags').overlaps(sqlKeywords))
+        .where(pg.array('tags').hasAnyOf(sqlKeywords))
       
       const compiled = query.compile()
       
@@ -355,7 +355,7 @@ describe('Array Security Tests', () => {
       expect(compiled.parameters).toEqual(sqlKeywords)
       
       // But should not appear as unparameterized SQL
-      const sqlWithoutArrayOperator = compiled.sql.replace('"tags" && ARRAY[', '')
+      const sqlWithoutArrayOperator = compiled.sql.replace('"tags" @> ARRAY[', '')
       sqlKeywords.forEach(keyword => {
         expect(sqlWithoutArrayOperator).not.toContain(keyword)
       })
@@ -380,7 +380,7 @@ describe('Array Security Tests', () => {
         const results = await integrationDb
           .selectFrom('products')
           .selectAll()
-          .where(pg.array('tags').includes(maliciousInput))
+          .where(pg.array('tags').hasAllOf([maliciousInput]))
           .execute()
 
         expect(Array.isArray(results)).toBe(true)
@@ -428,7 +428,7 @@ describe('Array Security Tests', () => {
           const results = await integrationDb
             .selectFrom('products')
             .select(['id', 'name', 'tags'])
-            .where(pg.array('tags').includes(specialChar))
+            .where(pg.array('tags').hasAllOf([specialChar]))
             .execute()
 
           expect(results.length).toBeGreaterThan(0)
@@ -461,7 +461,7 @@ describe('Array Security Tests', () => {
         integrationDb!
           .selectFrom('products')
           .selectAll()
-          .where(pg.array('tags').includes(maliciousQuery))
+          .where(pg.array('tags').hasAllOf([maliciousQuery]))
           .execute()
       )
 
@@ -491,7 +491,7 @@ describe('Array Security Tests', () => {
       const results = await integrationDb
         .selectFrom('products')
         .selectAll()
-        .where(pg.array('tags').overlaps(manyTags))
+        .where(pg.array('tags').hasAnyOf(manyTags))
         .execute()
 
       // Should execute without error
@@ -504,7 +504,7 @@ describe('Array Security Tests', () => {
       const query = compileDb
         .selectFrom('products')
         .selectAll()
-        .where(pg.array('tags').includes('test'))
+        .where(pg.array('tags').hasAllOf(['test']))
       
       const compiled = query.compile()
       
@@ -517,7 +517,7 @@ describe('Array Security Tests', () => {
       const query = compileDb
         .selectFrom('products')
         .selectAll()
-        .where(pg.array('products.tags').includes('test'))
+        .where(pg.array('products.tags').hasAllOf(['test']))
       
       const compiled = query.compile()
       
@@ -529,7 +529,7 @@ describe('Array Security Tests', () => {
       const query = compileDb
         .selectFrom('products')
         .selectAll()
-        .where(pg.array('tags"; DROP TABLE users; --').includes('test'))
+        .where(pg.array('tags"; DROP TABLE users; --').hasAllOf(['test']))
       
       const compiled = query.compile()
       
@@ -551,7 +551,7 @@ describe('Array Security Tests', () => {
       const query = compileDb
         .selectFrom('products')
         .selectAll()
-        .where(pg.array('tags').contains([]))
+        .where(pg.array('tags').hasAllOf([]))
       
       const compiled = query.compile()
       
@@ -565,7 +565,7 @@ describe('Array Security Tests', () => {
         const query = compileDb
           .selectFrom('products')
           .selectAll()
-          .where(pg.array('tags').includes('null'))
+          .where(pg.array('tags').hasAllOf(['null']))
         
         query.compile()
       }).not.toThrow()


### PR DESCRIPTION
## Summary
This PR refactors the array reading operations to use more intuitive, JavaScript-inspired method names that clearly communicate their purpose without requiring PostgreSQL knowledge.

### API Changes
- ✅ `includes()` and `contains()` → `hasAllOf()` - checks if array contains ALL specified elements  
- ✅ `overlaps()` → `hasAnyOf()` - checks if array contains ANY of the specified elements
- ❌ Removed `containedBy()` and `any()` methods for V1 simplicity
- ✅ Kept `length()`, `first()`, `last()` unchanged
- ✅ Kept all update operations (`append`, `prepend`, `remove`, etc.) unchanged

### Benefits
- **Intuitive naming**: Method names clearly state what they do (`hasAllOf` vs PostgreSQL's `@>`)
- **JavaScript familiarity**: Inspired by JS Array methods developers already know
- **Zero ambiguity**: No confusion about whether `contains()` checks one or all elements
- **Simplified V1**: Removed less commonly used methods for cleaner initial release

### Examples
```typescript
// Before
.where(pg.array('tags').includes('typescript'))
.where(pg.array('tags').contains(['react', 'vue']))  
.where(pg.array('userRoles').overlaps(['admin', 'moderator']))

// After  
.where(pg.array('tags').hasAllOf(['typescript']))
.where(pg.array('tags').hasAllOf(['react', 'vue']))
.where(pg.array('userRoles').hasAnyOf(['admin', 'moderator']))
```

## Test Plan
- [x] All existing tests updated and passing
- [x] API, SQL generation, security, and database integration tests
- [x] TypeScript type checking passes
- [x] Documentation updated in README

🤖 Generated with [Claude Code](https://claude.ai/code)